### PR TITLE
allow injecting the io.Writer to the slog.JSONHandler

### DIFF
--- a/log/slog_handler.go
+++ b/log/slog_handler.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"reflect"
@@ -114,13 +115,20 @@ func fmtErr(err error) slog.Value {
 }
 
 func SetupLog(logLevel slog.Level) {
+	setupLog(logLevel, os.Stdout)
+}
 
+func SetupLogWithWriter(logLevel slog.Level, writer io.Writer) {
+	setupLog(logLevel, writer)
+}
+
+func setupLog(logLevel slog.Level, writer io.Writer) {
 	handlerOptions := &slog.HandlerOptions{
 		Level:       logLevel, // Set the desired log level,
 		ReplaceAttr: replaceAttr,
 	}
 
-	jsonHandler := slog.NewJSONHandler(os.Stdout, handlerOptions)
+	jsonHandler := slog.NewJSONHandler(writer, handlerOptions)
 	ctxHandler := ContextHandler{jsonHandler}
 
 	ddvars := slog.Group("dd",

--- a/log/slog_handler_test.go
+++ b/log/slog_handler_test.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+func Test_SetupLogWithWriter_BytesBufferContainsLogs(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	testWriter := io.MultiWriter(os.Stderr, buf)
+	SetupLogWithWriter(slog.LevelInfo, testWriter)
+
+	testMessage := "this is our test message"
+	slog.InfoContext(context.Background(), testMessage, slog.String("key", "value"))
+
+	// Check if the log output contains the expected message
+	if buf.Len() == 0 {
+		t.Error("Expected log output, but got none.")
+	}
+	if buf.String() == "" {
+		t.Error("Expected log output, but got empty string.")
+	}
+	if !strings.Contains(buf.String(), testMessage) {
+		t.Errorf("Expected log output to contain %v, but got: %v", testMessage, buf.String())
+	}
+}


### PR DESCRIPTION
We need this for `mediafly-team/warehouse`, we have some code like this in that project:

```
buf := bytes.NewBuffer(nil)

...snip...

l.New(io.MultiWriter(os.Stderr, buf), prefix, l.Lshortfile|l.LstdFlags),

...snip...
```

Basically, when we log in warehouse, the `io.MultiWriter` puts the logs into a bytes buffer, which we then upload to our s3 bucket after, for example, a cron job or report generation.

To migrate that project to `log/slog` for DataDog shipping it would be nice to just drop that in instead of having to refactor all that byte schlepping. Eventually we can probably deprecate those log uploads but I'd rather do that at a later time.